### PR TITLE
Schedule display

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ Keys
 | `r`, `R`  | `r`eplace message | Attempts to retrieve the message under the cursor for editing and enters the reply buffer. Does not work if you are not the author of the post.
 | `X`, `D`  | `d`elete message  | Attempts to delete the message under the cursor. These are shifted characters to unintentional deletions.
 | `A`       | `a`ppend message  | Prompts the user for a channel name, which can be completed by tabbing. Enters the reply buffer, targeting the channel if it exists.
+| `K`       | `k` message       | Go to the message above the current one
+| `J`       | `j` message       | Go to the message below the current one
 | `gx`      | `G`o lin`ks`      | Attempts to open the word under the cursor as a link. Uses the currently-set link openers (see configuration)
 | `<c-g>`   | (See above)       | Attempt to open the first link before the current cursor position using the same method as `gx`.
 | `<a-g>`   | (See above)       | Attempt to open the first link before the current cursor position. Additional media content set on the message is opened, instead of the actual link.

--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ TODOs
     - Log in by means other than variables
     - Sorting the main buffer based on message channel id
     - Show visited links with extmark highlights instead of in-document colors using syntax
+    - Closing reply buffer just hides it
 
 - Unplanned - maybe soon?
     - Occasionally, the discord connection returns a 443 or similar error silently

--- a/README.md
+++ b/README.md
@@ -134,6 +134,15 @@ check for pastes are not bound.
 Default value is 8 (enabled).
 
 
+### `g:vimcord_shift_width`
+
+The number of spaces inserted before message contents. The author of a message
+is displayed on a separate line, with only one space prior. Runtime changes
+will not be applied to old messages.
+
+Default value is 4. Minimum value is 1.
+
+
 ### `g:vimcord_image_opener`
 
 Command name or path to executable to use to open image links.
@@ -202,7 +211,7 @@ TODOs
     - Occasionally, the discord connection returns a 443 or similar error silently
     - Display user connection status (sign column tricks?)
     - Separate multiple lines better (`linebreak` appears to allow horizontal tabs to do this?)
-    - Separate discord content out from "normal" reply window/message window pipeline
+    - Separate discord content out from "normal" reply window/message window pipeline (partially done)
 
 - Future work
     - Per-channel buffers: keep main accumulator, but extras can be opened (especially for muted channels)

--- a/autoload/vimcord/buffer.vim
+++ b/autoload/vimcord/buffer.vim
@@ -1,14 +1,12 @@
-function vimcord#buffer#add_extra_data(discord_channels_dict, discord_members_dict, user_id)
-  let g:vimcord["channel_names"] = a:discord_channels_dict
-  let g:vimcord["server_members"] = a:discord_members_dict
-  let g:vimcord["discord_user_id"] = a:user_id
-endfunction
+" buffer.vim
+" Functions relating to appending messages as groups of lines on a buffer, with
+" associated "extra" data.
+"
+" Functions here should loosely coupled with discord-related uids themselves
 
 " Return the first line and last lines that match the message id given
 " Lines returned are 0-indexed!
-" TODO: this should be message NUMBER not id
-"       we can identify the id first, then find the line...
-function vimcord#buffer#lines_by_message_id(message_id, ...)
+function vimcord#buffer#lines_by_message_number(message_number, ...)
   let buf = 0
   if a:0 >= 1
     let buf = a:1
@@ -18,12 +16,10 @@ function vimcord#buffer#lines_by_message_id(message_id, ...)
   let end_line = -1
 
   let lines_to_messages = nvim_buf_get_var(buf, "vimcord_lines_to_messages")
-  let messages_to_extra = nvim_buf_get_var(buf, "vimcord_messages_to_extra_data")
 
   for i in range(len(lines_to_messages) - 1, 0, -1)
-    let message_number = lines_to_messages[i]
-    let message_data = messages_to_extra[message_number]
-    if exists("message_data.message_id") && message_data["message_id"] == a:message_id
+    let this_number = lines_to_messages[i]
+    if this_number == a:message_number
       let start_line = min([start_line, i])
       let end_line = max([end_line, i])
     endif
@@ -66,45 +62,10 @@ function vimcord#buffer#append(discord_message, reply, discord_extra)
   " BUFFER NOT MODIFIABLE
 endfunction
 
-" TODO: improve this. use fewer message_id and more message_numbers
-"       alternatively, separate discord and general messaging more
-function s:redo_reply_extmarks(reply_id, new_contents)
-  call insert(a:new_contents, [" ╓─", "discordReply"], 0)
-
-  let reply_extmarks = nvim_buf_get_extmarks(
-        \ 0,
-        \ luaeval("vimcord.REPLY_NAMESPACE"),
-        \ 0,
-        \ -1,
-        \ {}
-        \ )
-
-  for [id, row, column] in reply_extmarks
-    if !exists("b:vimcord_lines_to_messages[row]")
-      " extmark still around, but not at an available line
-      call nvim_buf_del_extmark(0, luaeval("vimcord.REPLY_NAMESPACE"), id)
-    else
-      let message_number = b:vimcord_lines_to_messages[row]
-      if b:vimcord_messages_to_extra_data[message_number]["reply_message_id"] == a:reply_id
-        call nvim_buf_set_extmark(
-              \ 0,
-              \ luaeval("vimcord.REPLY_NAMESPACE"),
-              \ row,
-              \ column,
-              \ {
-              \   "id": id,
-              \   "virt_lines": [a:new_contents],
-              \   "virt_lines_above": v:true
-              \ })
-      endif
-    endif
-  endfor
-endfunction
-
-function vimcord#buffer#edit(discord_message, as_reply, discord_extra)
+function vimcord#buffer#edit(message_number, discord_message, discord_extra)
   " TODO: message number instead
   let [start_line, end_line] =
-        \ vimcord#buffer#lines_by_message_id(a:discord_extra["message_id"])
+        \ vimcord#buffer#lines_by_message_number(a:message_number)
   if start_line > end_line
     " Message not in buffer, fail silently
     return
@@ -116,7 +77,13 @@ function vimcord#buffer#edit(discord_message, as_reply, discord_extra)
   setlocal modifiable
 
   call nvim_buf_clear_namespace(0, luaeval("vimcord.LINKS_NAMESPACE"), start_line, end_line + 1)
-  call nvim_buf_clear_namespace(0, luaeval("vimcord.REPLY_NAMESPACE"), start_line, end_line + 1)
+  let reply_extmark = nvim_buf_get_extmarks(
+        \ 0,
+        \ luaeval("vimcord.REPLY_NAMESPACE"),
+        \ [start_line, 0],
+        \ [end_line + 1, -1],
+        \ { "details": 1 }
+        \ )
 
   " then set the rest of the line to the new contents
   let new_line_count = len(a:discord_message)
@@ -153,14 +120,20 @@ function vimcord#buffer#edit(discord_message, as_reply, discord_extra)
           \ )
   endif
   " --- Done, buffer lines match hidden lines--------------
-  call nvim_buf_set_extmark(
-        \ 0,
-        \ luaeval("vimcord.REPLY_NAMESPACE"),
-        \ start_line,
-        \ 0,
-        \ { "virt_lines": [a:reply], "virt_lines_above": v:true }
-        \ )
-  call s:redo_reply_extmarks(a:discord_extra["message_id"], a:as_reply)
+  " Move reply extmark
+  if len(reply_extmark) > 0
+    let extmark_content = reply_extmark[0]
+    call nvim_buf_set_extmark(
+          \ 0,
+          \ luaeval("vimcord.REPLY_NAMESPACE"),
+          \ start_line,
+          \ 0,
+          \ {
+          \   "id": extmark_content[0],
+          \   "virt_lines_above": v:true,
+          \   "virt_lines": extmark_content[3]["virt_lines"]
+          \ })
+  endif
 
   setlocal nomodifiable
   " BUFFER NOT MODIFIABLE
@@ -168,9 +141,9 @@ function vimcord#buffer#edit(discord_message, as_reply, discord_extra)
   return line(".", window) ==# (line("$", window) - new_line_count + old_count)
 endfunction
 
-function vimcord#buffer#delete(message_id)
+function vimcord#buffer#delete(message_number)
   let [start_line, end_line] =
-        \ vimcord#buffer#lines_by_message_id(a:message_id)
+        \ vimcord#buffer#lines_by_message_number(a:message_number)
   if start_line > end_line
     " Message not in buffer, fail silently
     return
@@ -185,14 +158,12 @@ function vimcord#buffer#delete(message_id)
   " remove old lines
   call remove(b:vimcord_lines_to_messages, start_line, end_line)
 
-  call s:redo_reply_extmarks(a:message_id, [[" ╓─(Deleted)", "discordReply"]])
-
   setlocal nomodifiable
   " BUFFER NOT MODIFIABLE
 endfunction
 
-function vimcord#buffer#add_link_extmarks(message_id, extmarks)
-  let [start_line, end_line] = vimcord#buffer#lines_by_message_id(a:message_id)
+function vimcord#buffer#add_link_extmarks(message_number, extmarks)
+  let [start_line, end_line] = vimcord#buffer#lines_by_message_number(a:message_number)
   let window = bufwinid(bufnr())
 
   if end_line + 1 > line("$", window)
@@ -225,41 +196,4 @@ endfunction
 function vimcord#buffer#add_media_content(line_number, media_content)
   let message_number = b:vimcord_lines_to_messages[a:line_number - 1]
   let b:vimcord_messages_to_extra_data[message_number]["media_content"] = a:media_content
-endfunction
-
-function vimcord#buffer#goto_reference() range
-  if len(b:vimcord_lines_to_messages) <= a:firstline - 1
-    echohl ErrorMsg
-    echo "No message under cursor"
-    echohl None
-    return
-  endif
-
-  let message_number = b:vimcord_lines_to_messages[a:line_number - 1]
-  let message_data = b:vimcord_messages_to_extra_data[message_number]
-  try
-    let reply_id = message_data["reply_message_id"]
-    if reply_id ==# v:null
-      echohl ErrorMsg
-      echo "Message has no reply"
-      echohl None
-      return
-    endif
-  catch
-    echohl ErrorMsg
-    echo "Message has no reply"
-    echohl None
-    return
-  endtry
-
-  let [start_line, end_line] = vimcord#buffer#lines_by_message_id(reply_id)
-  if end_line == -1
-    " TODO: try to prepend reference contents
-    echohl ErrorMsg
-    echo "Replied message not in buffer!"
-    echohl None
-    return
-  endif
-
-  call cursor(start_line + 1, 0)
 endfunction

--- a/autoload/vimcord/buffer.vim
+++ b/autoload/vimcord/buffer.vim
@@ -6,6 +6,8 @@ endfunction
 
 " Return the first line and last lines that match the message id given
 " Lines returned are 0-indexed!
+" TODO: this should be message NUMBER not id
+"       we can identify the id first, then find the line...
 function vimcord#buffer#lines_by_message_id(message_id, ...)
   let buf = 0
   if a:0 >= 1
@@ -14,13 +16,17 @@ function vimcord#buffer#lines_by_message_id(message_id, ...)
 
   let start_line = 1/0
   let end_line = -1
-  let i = 0
-  for data in nvim_buf_get_var(buf, "discord_content")
-    if exists("data.message_id") && data["message_id"] == a:message_id
+
+  let lines_to_messages = nvim_buf_get_var(buf, "vimcord_lines_to_messages")
+  let messages_to_extra = nvim_buf_get_var(buf, "vimcord_messages_to_extra_data")
+
+  for i in range(len(lines_to_messages) - 1, 0, -1)
+    let message_number = lines_to_messages[i]
+    let message_data = messages_to_extra[message_number]
+    if exists("message_data.message_id") && message_data["message_id"] == a:message_id
       let start_line = min([start_line, i])
       let end_line = max([end_line, i])
     endif
-    let i += 1
   endfor
 
   return [start_line, end_line]
@@ -30,7 +36,10 @@ function vimcord#buffer#append(discord_message, reply, discord_extra)
   " BUFFER MODIFIABLE
   setlocal modifiable
 
-  let line_number = len(b:discord_content)
+  let message_number = len(b:vimcord_messages_to_extra_data)
+  call add(b:vimcord_messages_to_extra_data, a:discord_extra)
+
+  let line_number = len(b:vimcord_lines_to_messages)
   let new_line_count = len(a:discord_message)
 
   let new_lines = map(a:discord_message, { k, v ->
@@ -38,9 +47,9 @@ function vimcord#buffer#append(discord_message, reply, discord_extra)
         \ })
 
   call setline(line_number + 1, new_lines)
-  for i in range(new_line_count)
-    call add(b:discord_content, a:discord_extra)
-  endfor
+  call extend(b:vimcord_lines_to_messages, repeat([message_number], new_line_count))
+
+  echom line_number new_line_count line("$", bufwinid(bufnr()))
 
   if len(a:reply) > 0
     call insert(a:reply, [" ╓─", "discordReply"], 0)
@@ -57,6 +66,8 @@ function vimcord#buffer#append(discord_message, reply, discord_extra)
   " BUFFER NOT MODIFIABLE
 endfunction
 
+" TODO: improve this. use fewer message_id and more message_numbers
+"       alternatively, separate discord and general messaging more
 function s:redo_reply_extmarks(reply_id, new_contents)
   call insert(a:new_contents, [" ╓─", "discordReply"], 0)
 
@@ -69,71 +80,92 @@ function s:redo_reply_extmarks(reply_id, new_contents)
         \ )
 
   for [id, row, column] in reply_extmarks
-    if !exists("b:discord_content[row]")
+    if !exists("b:vimcord_lines_to_messages[row]")
       " extmark still around, but not at an available line
       call nvim_buf_del_extmark(0, luaeval("vimcord.REPLY_NAMESPACE"), id)
-    elseif b:discord_content[row]["reply_message_id"] == a:reply_id
-      call nvim_buf_set_extmark(
-            \ 0,
-            \ luaeval("vimcord.REPLY_NAMESPACE"),
-            \ row,
-            \ column,
-            \ {
-            \   "id": id,
-            \   "virt_lines": [a:new_contents],
-            \   "virt_lines_above": v:true
-            \ })
+    else
+      let message_number = b:vimcord_lines_to_messages[row]
+      if b:vimcord_messages_to_extra_data[message_number]["reply_message_id"] == a:reply_id
+        call nvim_buf_set_extmark(
+              \ 0,
+              \ luaeval("vimcord.REPLY_NAMESPACE"),
+              \ row,
+              \ column,
+              \ {
+              \   "id": id,
+              \   "virt_lines": [a:new_contents],
+              \   "virt_lines_above": v:true
+              \ })
+      endif
     endif
   endfor
 endfunction
 
 function vimcord#buffer#edit(discord_message, as_reply, discord_extra)
+  " TODO: message number instead
   let [start_line, end_line] =
         \ vimcord#buffer#lines_by_message_id(a:discord_extra["message_id"])
   if start_line > end_line
     " Message not in buffer, fail silently
     return
   endif
+  let window = bufwinid(bufnr())
+  let message_number = b:vimcord_lines_to_messages[start_line]
 
   " BUFFER MODIFIABLE
   setlocal modifiable
 
   call nvim_buf_clear_namespace(0, luaeval("vimcord.LINKS_NAMESPACE"), start_line, end_line + 1)
-  if start_line + 1 <= end_line
-    call deletebufline(bufname(), start_line + 1, end_line)
-  end
+  call nvim_buf_clear_namespace(0, luaeval("vimcord.REPLY_NAMESPACE"), start_line, end_line + 1)
 
   " then set the rest of the line to the new contents
   let new_line_count = len(a:discord_message)
   let new_lines = map(a:discord_message, { k, v ->
         \ (repeat(" ", k == 0 ? 0 : g:vimcord_shift_width)) . v
         \ })
-  call setline(start_line + 1, new_lines)
+  call append(start_line, new_lines)
+
+  " Delete all lines of the original message
+  call deletebufline(bufname(), start_line + new_line_count + 1, end_line + new_line_count + 1)
 
   " --- Compute new hidden data ---------------------------
   let old_count = end_line - start_line + 1
 
   " set current lines
+  let b:vimcord_messages_to_extra_data[message_number] = a:discord_extra
   for i in range(min([new_line_count, old_count]))
-    let b:discord_content[start_line + i] = a:discord_extra
+    let b:vimcord_lines_to_messages[start_line + i] = message_number
   endfor
 
   if old_count < new_line_count
     " add new lines
-    for i in range(new_line_count - old_count)
-      call insert(b:discord_content, a:discord_extra, start_line)
-    endfor
+    call extend(
+          \ b:vimcord_lines_to_messages,
+          \ repeat([message_number], new_line_count - old_count),
+          \ start_line
+          \ )
   elseif old_count > new_line_count
     " remove old lines
-    call remove(b:discord_content, start_line + (old_count - new_line_count), end_line)
+    call remove(
+          \ b:vimcord_lines_to_messages,
+          \ end_line - (old_count - new_line_count - 1),
+          \ end_line
+          \ )
   endif
   " --- Done, buffer lines match hidden lines--------------
+  call nvim_buf_set_extmark(
+        \ 0,
+        \ luaeval("vimcord.REPLY_NAMESPACE"),
+        \ start_line,
+        \ 0,
+        \ { "virt_lines": [a:reply], "virt_lines_above": v:true }
+        \ )
   call s:redo_reply_extmarks(a:discord_extra["message_id"], a:as_reply)
 
   setlocal nomodifiable
   " BUFFER NOT MODIFIABLE
 
-  return line(".") == (line("$") - new_line_count + old_count)
+  return line(".", window) ==# (line("$", window) - new_line_count + old_count)
 endfunction
 
 function vimcord#buffer#delete(message_id)
@@ -151,7 +183,7 @@ function vimcord#buffer#delete(message_id)
   " delete lines after first one of the message
   call deletebufline(bufname(), start_line + 1, end_line + 1)
   " remove old lines
-  call remove(b:discord_content, start_line, end_line)
+  call remove(b:vimcord_lines_to_messages, start_line, end_line)
 
   call s:redo_reply_extmarks(a:message_id, [[" ╓─(Deleted)", "discordReply"]])
 
@@ -164,7 +196,9 @@ function vimcord#buffer#add_link_extmarks(message_id, extmarks)
   let window = bufwinid(bufnr())
 
   if end_line + 1 > line("$", window)
-    echoerr "Could not add links to message id " .. a:message_id .. "!"
+    echohl ErrorMsg
+    echom "Could not add links to message id " .. a:message_id .. "!"
+    echohl None
     return -1
   end
 
@@ -182,38 +216,48 @@ function vimcord#buffer#add_link_extmarks(message_id, extmarks)
         \ { "virt_lines": virt_lines }
         \ )
 
-  if line(".") == line("$")
+  if line(".", window) == line("$", window)
     normal zb
   end
   return end_line
 endfunction
 
 function vimcord#buffer#add_media_content(line_number, media_content)
-  let b:discord_content[a:line_number]["media_content"] = a:media_content
+  let message_number = b:vimcord_lines_to_messages[a:line_number - 1]
+  let b:vimcord_messages_to_extra_data[message_number]["media_content"] = a:media_content
 endfunction
 
 function vimcord#buffer#goto_reference() range
-  if len(b:discord_content) <= a:firstline - 1
-    echoerr "No message under cursor"
+  if len(b:vimcord_lines_to_messages) <= a:firstline - 1
+    echohl ErrorMsg
+    echo "No message under cursor"
+    echohl None
     return
   endif
 
-  let message_data = b:discord_content[a:firstline - 1]
+  let message_number = b:vimcord_lines_to_messages[a:line_number - 1]
+  let message_data = b:vimcord_messages_to_extra_data[message_number]
   try
     let reply_id = message_data["reply_message_id"]
     if reply_id ==# v:null
-      echoerr "Message has no reply"
+      echohl ErrorMsg
+      echo "Message has no reply"
+      echohl None
       return
     endif
   catch
-    echoerr "Message has no reply"
+    echohl ErrorMsg
+    echo "Message has no reply"
+    echohl None
     return
   endtry
 
   let [start_line, end_line] = vimcord#buffer#lines_by_message_id(reply_id)
   if end_line == -1
     " TODO: try to prepend reference contents
-    echoerr "Replied message not in buffer!"
+    echohl ErrorMsg
+    echo "Replied message not in buffer!"
+    echohl None
     return
   endif
 

--- a/autoload/vimcord/link.vim
+++ b/autoload/vimcord/link.vim
@@ -68,6 +68,16 @@ endfunction
 function vimcord#link#open_most_recent(only_media)
   let prev = getcurpos()
 
+  " scroll to the last line of the message
+  let current_message = b:vimcord_lines_to_messages[line(".") - 1]
+  while 1
+    let next_message = get(b:vimcord_lines_to_messages, line("."), -1)
+    if next_message !=# current_message
+      break
+    endif
+    normal! j
+  endwhile
+
   " TODO: search does not get last match, even with z flag with cursor at line end
   normal $
   let try_search = search("https\\{0,1\\}:\\/\\/.\\+\\.[^` \\x1b]\\+", 'b')

--- a/autoload/vimcord/link.vim
+++ b/autoload/vimcord/link.vim
@@ -7,19 +7,8 @@ function vimcord#link#open_media_under_cursor()
     return
   endif
 
-  let last_message = message
-  while 1
-    let startline += 1
-    let this_number = b:vimcord_lines_to_messages[startline]
-    if !exists("b:vimcord_lines_to_messages[startline]") ||
-          \ get(get(b:vimcord_messages_to_extra_data, this_number, {}), "message_id", "") !=# message["message_id"]
-      break
-    endif
-    let last_message = b:vimcord_messages_to_extra_data[this_number]
-  endwhile
-
-  if exists("last_message.media_content")
-    for link in get(last_message, "media_content", [])
+  if exists("message.media_content")
+    for link in get(message, "media_content", [])
       call s:open_media(link, 0)
     endfor
   endif

--- a/autoload/vimcord/link.vim
+++ b/autoload/vimcord/link.vim
@@ -1,6 +1,7 @@
 function vimcord#link#open_media_under_cursor()
   let startline = line(".") - 1
-  let message = b:discord_content[startline]
+  let message_number = b:vimcord_lines_to_messages[startline]
+  let message = b:vimcord_messages_to_extra_data[message_number]
 
   if !exists("message.message_id")
     return
@@ -9,11 +10,12 @@ function vimcord#link#open_media_under_cursor()
   let last_message = message
   while 1
     let startline += 1
-    if !exists("b:discord_content[startline]") ||
-          \ get(b:discord_content[startline], "message_id", "") !=# message["message_id"]
+    let this_number = b:vimcord_lines_to_messages[startline]
+    if !exists("b:vimcord_lines_to_messages[startline]") ||
+          \ get(get(b:vimcord_messages_to_extra_data, this_number, {}), "message_id", "") !=# message["message_id"]
       break
     endif
-    let last_message = b:discord_content[startline]
+    let last_message = b:vimcord_messages_to_extra_data[this_number]
   endwhile
 
   if exists("last_message.media_content")

--- a/doc/vimcord.txt
+++ b/doc/vimcord.txt
@@ -66,6 +66,10 @@ r, R    `r`eplace message       Attempts to retrieve the message under the
                               Does not work if you are not the author of the
                               post.
 
+K       `k` message             Go to the message above the current one
+
+J       `j` message             Go to the message below the current one
+
 X, D    `d`elete message        Attempts to delete the message under the cursor.
                               These are shifted characters to unintentional
                               deletions.

--- a/doc/vimcord.txt
+++ b/doc/vimcord.txt
@@ -54,7 +54,7 @@ DISCORD MESSAGE BUFFER                                  *vimcord-discord-message
 
 The following key bindings are available from the Discord message buffer.
 
-i       `i`nsert message.       Enters the reply buffer, targeting the channel
+i       `i`nsert message        Enters the reply buffer, targeting the channel
                               of the message currently under the cursor.
 
 I       `I`nsert reply          Like `i`, but marks the message under the
@@ -137,7 +137,6 @@ in your `.vimrc` is dangerous and inadvisable.
 
 Work is planned for making this better.
 
-
 g:vimcord_dnd_paste_threshold                           *g:vimcord_dnd_paste_threshold*
 
 The minimum number of inserted characters for which the reply buffer can
@@ -146,6 +145,15 @@ When less than or equal to zero, disables, events in the reply buffer which
 check for pastes are not bound.
 
 Default value is 8 (enabled).
+
+
+g:vimcord_shift_width                                   *g:vimcord_shift_width*
+
+The number of spaces inserted before message contents. The author of a message
+is displayed on a separate line, with only one space prior. Runtime changes
+will not be applied to old messages.
+
+Default value is 4. Minimum value is 1.
 
 
 g:vimcord_image_opener                                  *g:vimcord_image_opener*

--- a/ftplugin/discord_messages.vim
+++ b/ftplugin/discord_messages.vim
@@ -44,6 +44,19 @@ if !(exists("b:vimcord_lines_to_messages") && exists("b:vimcord_messages_to_extr
   finish
 endif
 
+function! s:scroll_message(direction)
+  let message_number = b:vimcord_lines_to_messages[line(".") - 1]
+  let last_line = -1
+  while 1
+    let new_message_number = get(b:vimcord_lines_to_messages, line(".") - 1, -1)
+    if new_message_number !=# message_number || line(".") ==# last_line
+      break
+    endif
+    let last_line = line(".")
+    exe "normal " .. a:direction
+  endwhile
+endfunction
+
 " Plugin keys
 nnoremap <silent><buffer> <Plug>(vimcord_open_reply)
       \ :<c-u>.call vimcord#action#open_reply(0)<cr>
@@ -75,6 +88,12 @@ nnoremap <silent><buffer> <Plug>(vimcord_open_media_under_cursor)
 nnoremap <silent><buffer> <Plug>(vimcord_open_last_media)
       \ :<c-u>call vimcord#link#open_most_recent(1)<cr>
 
+nnoremap <silent><buffer> <Plug>(vimcord_message_above)
+      \ :<c-u>call <SID>scroll_message("k")<cr>
+
+nnoremap <silent><buffer> <Plug>(vimcord_message_below)
+      \ :<c-u>call <SID>scroll_message("j")<cr>
+
 " Actual keymaps
 nmap <buffer> i <Plug>(vimcord_open_reply)
 nmap <buffer> I <Plug>(vimcord_open_direct_reply)
@@ -86,6 +105,9 @@ nmap <buffer> A <Plug>(vimcord_enter_channel)
 
 nmap <buffer> r <Plug>(vimcord_edit)
 nmap <buffer> R <Plug>(vimcord_edit)
+
+nmap <buffer> K <Plug>(vimcord_message_above)
+nmap <buffer> J <Plug>(vimcord_message_below)
 
 nmap <buffer> gx <Plug>(vimcord_open_under_cursor)
 nmap <buffer> <c-g> <Plug>(vimcord_open_last_link)

--- a/ftplugin/discord_messages.vim
+++ b/ftplugin/discord_messages.vim
@@ -5,7 +5,6 @@ setlocal nonumber
 setlocal wrap
 setlocal linebreak
 setlocal breakindent
-setlocal breakindentopt=shift:4
 
 " Remove escape characters used for coloring member names
 function s:strip_colors(event)

--- a/ftplugin/discord_messages.vim
+++ b/ftplugin/discord_messages.vim
@@ -40,7 +40,7 @@ augroup discord_messages
   autocmd WinEnter <buffer> setlocal nocursorline
 augroup end
 
-if !(exists("b:discord_content"))
+if !(exists("b:vimcord_lines_to_messages") && exists("b:vimcord_messages_to_extra_data"))
   finish
 endif
 

--- a/ftplugin/discord_messages.vim
+++ b/ftplugin/discord_messages.vim
@@ -61,7 +61,7 @@ nnoremap <silent><buffer> <Plug>(vimcord_edit)
       \ :<c-u>.call vimcord#action#edit_start()<cr>
 
 nnoremap <silent><buffer> <Plug>(vimcord_goto_reference)
-      \ :<c-u>.call vimcord#buffer#goto_reference()<cr>
+      \ :<c-u>.call vimcord#discord#goto_reference()<cr>
 
 nnoremap <silent><buffer> <Plug>(vimcord_open_under_cursor)
       \ :<c-u>call vimcord#link#open_under_cursor(0)<cr>

--- a/ftplugin/discord_reply.vim
+++ b/ftplugin/discord_reply.vim
@@ -109,7 +109,6 @@ function s:add_drag_and_drop(position)
   if filename[0] ==# filename[-1:] && (filename[0] ==# "'" || filename[0] ==# "\"")
     let filename = filename[1:-2]
   endif
-  echom filename
   if filereadable(filename)
     " remove the filename we just inserted
     exe "normal \"_d" .. s:last_move_size .. "h"

--- a/ftplugin/discord_reply.vim
+++ b/ftplugin/discord_reply.vim
@@ -1,4 +1,7 @@
 setlocal nonumber
+setlocal wrap
+setlocal linebreak
+setlocal breakindent
 " setlocal completefunc="s:complete_reply"
 exe "setlocal completefunc=" .. expand("<SID>") .. "complete_reply"
 

--- a/lua/vimcord.lua
+++ b/lua/vimcord.lua
@@ -30,7 +30,8 @@ function vimcord.create_window(create_tab, ...)
 
   local reply_window = vim.call("vimcord#create_reply_window", true)
   -- set options for new buffer/window
-  vim.api.nvim_buf_set_var(buf, "discord_content", {})
+  vim.api.nvim_buf_set_var(buf, "vimcord_lines_to_messages", {})
+  vim.api.nvim_buf_set_var(buf, "vimcord_messages_to_extra_data", {})
   vim.api.nvim_buf_set_option(buf, "modifiable", false)
   vim.api.nvim_buf_set_option(buf, "filetype", "discord_messages")
 
@@ -41,90 +42,108 @@ function vimcord.create_window(create_tab, ...)
   return buf
 end
 
+
+-- all
 function vimcord.append_to_buffer(buffer, discord_message, reply, discord_extra)
-  local windows = vim.call("win_findbuf", buffer)
+  vim.print({"SCHEDULE APPEND", discord_extra})
+  vim.schedule(function()
+    vim.print({"HERE APPENDING", discord_extra})
+    local windows = vim.call("win_findbuf", buffer)
 
-  vim.api.nvim_buf_call(buffer, function()
-    vim.call("vimcord#buffer#append", discord_message, reply, discord_extra)
-  end)
-
-  for i = 1, #windows do
-    vim.api.nvim_win_call(windows[i], function()
-      vim.call("vimcord#scroll_cursor", #discord_message)
+    vim.api.nvim_buf_call(buffer, function()
+      vim.call("vimcord#buffer#append", discord_message, reply, discord_extra)
     end)
-  end
+
+    for i = 1, #windows do
+      vim.api.nvim_win_call(windows[i], function()
+        vim.call("vimcord#scroll_cursor", #discord_message)
+      end)
+    end
+  end)
 end
 
 function vimcord.append_many_to_buffer(buffer, discord_messages)
-  local windows = vim.call("win_findbuf", buffer)
+  vim.schedule(function()
+    vim.print("HERE APPENDING MANY")
+    local line_count = 0
+    vim.api.nvim_buf_call(buffer, function()
+      for _, message in pairs(discord_messages) do
+        vim.call("vimcord#buffer#append", unpack(message))
+        local contents = message[1]
+        line_count = line_count + #contents
+      end
+    end)
 
-  local line_count = 0
-  vim.api.nvim_buf_call(buffer, function()
-    for _, message in pairs(discord_messages) do
-      vim.call("vimcord#buffer#append", unpack(message))
-      local contents = message[1]
-      line_count = line_count + #contents
+    local windows = vim.call("win_findbuf", buffer)
+    for i = 1, #windows do
+      vim.api.nvim_win_call(windows[i], function()
+        vim.call("vimcord#scroll_cursor", line_count - 1)
+      end)
     end
   end)
-
-  for i = 1, #windows do
-    vim.api.nvim_win_call(windows[i], function()
-      vim.call("vimcord#scroll_cursor", line_count - 1)
-    end)
-  end
 end
 
 function vimcord.edit_buffer_message(buffer, discord_message, as_reply, discord_extra)
-  local windows = vim.call("win_findbuf", buffer)
+  vim.print({"SCHEDULED EDIT", discord_extra})
+  vim.schedule(function()
+    vim.print({"HERE EDIT", discord_extra})
+    local windows = vim.call("win_findbuf", buffer)
 
-  local added_lines = vim.api.nvim_buf_call(buffer, function()
-    return vim.call("vimcord#buffer#edit", discord_message, as_reply, discord_extra)
-  end)
-
-  for i = 1, #windows do
-    vim.api.nvim_win_call(windows[i], function()
-      vim.call("vimcord#scroll_cursor", #discord_message)
+    local added_lines = vim.api.nvim_buf_call(buffer, function()
+      return vim.call("vimcord#buffer#edit", discord_message, as_reply, discord_extra)
     end)
-  end
+
+    for i = 1, #windows do
+      vim.api.nvim_win_call(windows[i], function()
+        vim.call("vimcord#scroll_cursor", #discord_message)
+      end)
+    end
+  end)
 end
 
 function vimcord.delete_buffer_message(buffer, discord_message_id)
-  vim.api.nvim_buf_call(buffer, function()
-    vim.call("vimcord#buffer#delete", discord_message_id)
+  vim.schedule(function()
+    vim.api.nvim_buf_call(buffer, function()
+      vim.call("vimcord#buffer#delete", discord_message_id)
+    end)
   end)
 end
 
 function vimcord.recolor_visited_links(buffer, unvisited)
-  vim.api.nvim_buf_set_option(buffer, "modifiable", true)
+  vim.schedule(function()
+    vim.api.nvim_buf_set_option(buffer, "modifiable", true)
 
-  --fetch the cursor
-  local windows = vim.call("win_findbuf", buffer)
-  local cursor = vim.api.nvim_win_get_cursor(windows[1])
+    --fetch the cursor
+    local windows = vim.call("win_findbuf", buffer)
+    local cursor = vim.api.nvim_win_get_cursor(windows[1])
 
-  -- even in vimscript, this would be an execute command, so I'm not torn up about it being here
-  for _, j in pairs(unvisited) do
-    local escape_slashes = j:gsub("/", "\\/")
-    pcall(function()
-      vim.cmd(
-        "keeppatterns %sno/\\(\\%x1B\\)100 \\(" .. escape_slashes ..
-        " \\%x1B\\)/\\1VL \\2/g"
-      )
-    end)
-  end
+    -- even in vimscript, this would be an execute command, so I'm not torn up about it being here
+    for _, j in pairs(unvisited) do
+      local escape_slashes = j:gsub("/", "\\/")
+      pcall(function()
+        vim.cmd(
+          "keeppatterns %sno/\\(\\%x1B\\)100 \\(" .. escape_slashes ..
+          " \\%x1B\\)/\\1VL \\2/g"
+        )
+      end)
+    end
 
-  --and restore it
-  vim.api.nvim_win_set_cursor(windows[1], cursor)
+    --and restore it
+    vim.api.nvim_win_set_cursor(windows[1], cursor)
 
-  vim.api.nvim_buf_set_option(buffer, "modifiable", false)
+    vim.api.nvim_buf_set_option(buffer, "modifiable", false)
+  end)
 end
 
 function vimcord.add_link_extmarks(buffer, message_id, extmark_content, media_links)
-  vim.api.nvim_buf_call(buffer, function()
-    -- extmarks
-    local line_number = vim.call("vimcord#buffer#add_link_extmarks", message_id, extmark_content)
-    -- media content
-    if line_number > 0 then
-      vim.call("vimcord#buffer#add_media_content", line_number, media_links)
-    end
+  vim.schedule(function()
+    vim.api.nvim_buf_call(buffer, function()
+      -- extmarks
+      local line_number = vim.call("vimcord#buffer#add_link_extmarks", message_id, extmark_content)
+      -- media content
+      if line_number > 0 then
+        vim.call("vimcord#buffer#add_media_content", line_number, media_links)
+      end
+    end)
   end)
 end

--- a/lua/vimcord.lua
+++ b/lua/vimcord.lua
@@ -9,7 +9,7 @@ function vimcord.create_window(create_tab, ...)
   local buf = ...
   -- get a new buffer
   if buf == nil then
-    buf = vim.api.nvim_create_buf(false, true)
+    buf = vim.call("vimcord#buffer#create_buffer")
   end
   -- decide which window to use
   local win
@@ -27,16 +27,10 @@ function vimcord.create_window(create_tab, ...)
   end
   -- cursor is currently in the new window
   vim.api.nvim_win_set_buf(win, buf)
-
-  local reply_window = vim.call("vimcord#create_reply_window", true)
-  -- set options for new buffer/window
-  vim.api.nvim_buf_set_var(buf, "vimcord_lines_to_messages", {})
-  vim.api.nvim_buf_set_var(buf, "vimcord_messages_to_extra_data", {})
-  vim.api.nvim_buf_set_option(buf, "modifiable", false)
+  -- hold off until we've got a window to set the filetype
   vim.api.nvim_buf_set_option(buf, "filetype", "discord_messages")
 
-  -- ditto for the reply window
-  vim.api.nvim_buf_set_var(vim.g.vimcord.reply_buffer, "vimcord_target_buffer", buf)
+  local reply_window = vim.call("vimcord#create_reply_window", true)
 
   vim.call("win_gotoid", win)
   return buf
@@ -157,7 +151,7 @@ function vimcord.add_link_extmarks(buffer, discord_message_id, extmark_content, 
       local line_number = vim.call("vimcord#buffer#add_link_extmarks", message_number, extmark_content)
       -- media content
       if line_number > 0 then
-        vim.call("vimcord#buffer#add_media_content", line_number, media_links)
+        vim.call("vimcord#buffer#add_media_content", message_number, media_links)
       end
     end)
   end)

--- a/lua/vimcord.lua
+++ b/lua/vimcord.lua
@@ -41,15 +41,11 @@ function vimcord.create_window(create_tab, ...)
   return buf
 end
 
-function vimcord.append_to_buffer(buffer, discord_message, reply, discord_extra, add_spaces)
+function vimcord.append_to_buffer(buffer, discord_message, reply, discord_extra)
   local windows = vim.call("win_findbuf", buffer)
-  local bufindentopt = vim.api.nvim_win_get_option(windows[1], "breakindentopt")
-  local split_width = tonumber(
-    vim.split(vim.split(bufindentopt, "shift:")[2] or "", ",")[1]
-  ) or 0
 
   vim.api.nvim_buf_call(buffer, function()
-    vim.call("vimcord#buffer#append", split_width, discord_message, reply, discord_extra, add_spaces)
+    vim.call("vimcord#buffer#append", discord_message, reply, discord_extra)
   end)
 
   for i = 1, #windows do
@@ -61,15 +57,11 @@ end
 
 function vimcord.append_many_to_buffer(buffer, discord_messages)
   local windows = vim.call("win_findbuf", buffer)
-  local bufindentopt = vim.api.nvim_win_get_option(windows[1], "breakindentopt")
-  local split_width = tonumber(
-    vim.split(vim.split(bufindentopt, "shift:")[2] or "", ",")[1]
-  ) or 0
 
   local line_count = 0
   vim.api.nvim_buf_call(buffer, function()
     for _, message in pairs(discord_messages) do
-      vim.call("vimcord#buffer#append", buffer, unpack(message))
+      vim.call("vimcord#buffer#append", unpack(message))
       local contents = message[1]
       line_count = line_count + #contents
     end
@@ -84,13 +76,9 @@ end
 
 function vimcord.edit_buffer_message(buffer, discord_message, as_reply, discord_extra)
   local windows = vim.call("win_findbuf", buffer)
-  local bufindentopt = vim.api.nvim_win_get_option(windows[1], "breakindentopt")
-  local split_width = tonumber(
-    vim.split(vim.split(bufindentopt, "shift:")[2] or "", ",")[1]
-  ) or 0
 
   local added_lines = vim.api.nvim_buf_call(buffer, function()
-    return vim.call("vimcord#buffer#edit", split_width, discord_message, as_reply, discord_extra)
+    return vim.call("vimcord#buffer#edit", discord_message, as_reply, discord_extra)
   end)
 
   for i = 1, #windows do

--- a/plugin/vimcord.vim
+++ b/plugin/vimcord.vim
@@ -8,10 +8,11 @@ lua require("vimcord")
 let g:vimcord_discord_username = get(g:, "vimcord_discord_username", "")
 let g:vimcord_discord_password = get(g:, "vimcord_discord_password", "")
 let g:vimcord_dnd_paste_threshold = get(g:, "vimcord_dnd_paste_threshold", 8)
+let g:vimcord_shift_width = max([get(g:, "vimcord_shift_width", 4), 1])
 
 " Link open settings
-let g:vimcord_image_opener = get(g:, "vimcord_image_link_formats", "feh")
-let g:vimcord_video_opener = get(g:, "vimcord_image_link_formats", "mpv")
+let g:vimcord_image_opener = get(g:, "vimcord_image_opener", "feh")
+let g:vimcord_video_opener = get(g:, "vimcord_video_opener", "mpv")
 
 let g:vimcord_image_link_formats = get(g:, "vimcord_image_link_formats", [])
 let g:vimcord_video_link_formats = get(g:, "vimcord_video_link_formats", [

--- a/rplugin/python3/vimcord/__init__.py
+++ b/rplugin/python3/vimcord/__init__.py
@@ -85,5 +85,5 @@ class Vimcord:
     def open_bridge(self, buffer=None):
         self.bridge = DiscordBridge(self, buffer)
 
-    def notify(self, msg):
-        self.nvim.async_call(self.nvim.api.notify, msg, 4, {})
+    def notify(self, msg, level=4):
+        self.nvim.async_call(self.nvim.api.notify, msg, level, {})

--- a/rplugin/python3/vimcord/bridge.py
+++ b/rplugin/python3/vimcord/bridge.py
@@ -127,7 +127,7 @@ class DiscordBridge:
         function to add them.
         '''
         formatted_opengraph = await asyncio.gather(*[
-            get_link_content(link) for link in links
+            get_link_content(link, notify_func=self.plugin.notify) for link in links
         ])
         # flatten results
         # TODO: intercalate?

--- a/rplugin/python3/vimcord/bridge.py
+++ b/rplugin/python3/vimcord/bridge.py
@@ -59,6 +59,7 @@ class DiscordBridge:
         self.discord_pipe.event("message_edit", self.on_message_edit)
         self.discord_pipe.event("message_delete", self.on_message_delete)
         self.discord_pipe.event("dm_update", self.on_dm_update)
+        self.discord_pipe.event("error", self.on_error)
 
         await self.preamble()
 
@@ -300,6 +301,10 @@ class DiscordBridge:
     async def on_dm_update(self, dm):
         '''DM discord user status change'''
         #TODO: direct message updates
+
+    async def on_error(self, exc):
+        '''On error received from server'''
+        self.plugin.notify(f"Server encountered error: {exc}")
 
     #---Check if a channel is muted---------------------------------------------
     def is_muted(self, server, channel):

--- a/rplugin/python3/vimcord/bridge.py
+++ b/rplugin/python3/vimcord/bridge.py
@@ -199,8 +199,7 @@ class DiscordBridge:
                 {
                     "channel_id": post.channel.id,
                     "server_id":  (post.server.id if post.server is not None else None),
-                },
-                False
+                }
             ))
 
         _, reply, message = clean_post(self, post)
@@ -215,8 +214,7 @@ class DiscordBridge:
                 "channel_id": post.channel.id,
                 "server_id":  (post.server.id if post.server is not None else None),
                 "reply_message_id": (post.referenced_message.id if post.referenced_message is not None else None)
-            },
-            True
+            }
         ))
         return ret
 
@@ -232,8 +230,7 @@ class DiscordBridge:
                 {
                     "channel_id": post.channel.id,
                     "server_id":  (post.server.id if post.server is not None else None),
-                },
-                False
+                }
             )
 
         links, reply, message = clean_post(self, post)

--- a/rplugin/python3/vimcord/bridge.py
+++ b/rplugin/python3/vimcord/bridge.py
@@ -160,7 +160,7 @@ class DiscordBridge:
         def on_ready_callback():
             log.info("Sending data to vim...")
             self.plugin.nvim.api.call_function(
-                "vimcord#buffer#add_extra_data",
+                "vimcord#discord#add_extra_data",
                 [
                     { i.id: format_channel(i, raw=True)
                       for i in self.unmuted_channels },

--- a/rplugin/python3/vimcord/formatting.py
+++ b/rplugin/python3/vimcord/formatting.py
@@ -6,6 +6,7 @@ from vimcord.links import LINK_RE
 log = logging.getLogger(__name__)
 log.setLevel("DEBUG")
 
+INDENT_SIZE = 3
 MAX_REPLY_WIDTH = 100
 
 def syntax_color(color, text, literal=False):
@@ -48,7 +49,7 @@ def clean_post(bridge, post: discord.Message, no_reply=False):
     if not no_reply and post.referenced_message is not None:
         reply = extmark_post(bridge, post.referenced_message)
 
-    return links, reply, author + ": " + content
+    return links, reply, f" {author}:\n" + content.strip()
 
 def extmark_post(bridge, post: discord.Message):
     embeds = [i["url"] for i in post.attachments]
@@ -70,7 +71,7 @@ def extmark_post(bridge, post: discord.Message):
 
     return [
         [post.author.display_name, f"discordColor{color_number}"],
-        [f": {content}", "discordReply"]
+        [f": {content.strip()}", "discordReply"]
     ]
 
 def format_channel(channel, width=80, raw=False):

--- a/rplugin/python3/vimcord/pickle_pipe.py
+++ b/rplugin/python3/vimcord/pickle_pipe.py
@@ -105,6 +105,10 @@ class PickleServerProtocol(asyncio.Protocol):
                 log.error("Could not pickle %s!", args)
                 self.transport.write(encode_for_pipe(base + [PicklePipeException()]))
 
+    def write_error(self, exc):
+        '''Write an exception to the pipe, fewer questions asked'''
+        self.write(["event", "error"], [exc])
+
     async def _reply(self, unpickled):
         request_id, verb, data = unpickled
         args, kwargs = data


### PR DESCRIPTION
- Message author is printed on separate line; consequently, `breakindentopt` is no longer set directly and is now controlled with a global variable
- Message buffer changes are scheduled on the main event loop to reduce likelihood of getting desynced.
- Extra message data is not copied for every line of the message -- each line in a message buffer has a corresponding message number, which can be mapped back to the extra data